### PR TITLE
Add support for building on MacOS ARM

### DIFF
--- a/library/build_ffmpeg.sh
+++ b/library/build_ffmpeg.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 # =============== Build definitions ===============
 
@@ -112,7 +112,7 @@ while [[ $# -gt 0 ]]; do
             for ABI in $ABI_FILTERS; do
                 DIR="$(pwd)/libs/$ABI"
                 mkdir -p "$DIR"
-                cp -av -t "$DIR" $BUILD_ROOT/$ABI/lib/lib{avformat,avcodec,swresample,avutil}.so
+                cp -av $BUILD_ROOT/$ABI/lib/lib{avformat,avcodec,swresample,avutil}.so "$DIR"
             done
             exit 0
             ;;
@@ -154,7 +154,10 @@ if [ -z "$NDK_DIR" ]; then
 fi
 
 TOOLCHAIN="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_TAG"
-
+if [ ! -e $TOOLCHAIN ]; then
+  # On MacOS arm64, the NDK still uses the darwin-x86_64 folder
+  TOOLCHAIN="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_NAME-x86_64"
+fi
 
 # =============== Actual build ===============
 
@@ -167,6 +170,7 @@ if [ -z "$INIT_ONLY" ]; then
     echo "Downloading LIBMP3LAME:"
     curl -L "https://altushost-swe.dl.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz" | tar xz
     mv lame-3.100 "$LIBMP3LAME_ROOT"
+    patch $LIBMP3LAME_ROOT/configure < dependencies/libmp3lame-cross.patch
   fi
 
   if [ ! -e $LIBOGG_ROOT ]; then

--- a/library/dependencies/libmp3lame-cross.patch
+++ b/library/dependencies/libmp3lame-cross.patch
@@ -1,0 +1,40 @@
+--- a/configure
++++ b/configure
+@@ -17526,16 +17526,10 @@
+ 					OPTIMIZATION="${OPTIMIZATION} -march=i486"
+ 					;;
+ 				*586)
+-					OPTIMIZATION="${OPTIMIZATION} -march=i586 \
+-						-mtune=native"
+-					;;
+-				*686)
+-					OPTIMIZATION="${OPTIMIZATION} -march=i686 \
+-						-mtune=native"
++					OPTIMIZATION="${OPTIMIZATION} -march=i586"
+ 					;;
+ 				*86)
+-					OPTIMIZATION="${OPTIMIZATION} -march=native \
+-						-mtune=native"
++					OPTIMIZATION="${OPTIMIZATION} -march=i686"
+ 					;;
+ 				arm*-gnueabi)
+ 					if  -z "$(echo ${GCC_version} | awk '/4\.0/')" ; then
+@@ -17579,16 +17573,10 @@
+ 			OPTIMIZATION="${OPTIMIZATION} -march=i486"
+ 			;;
+ 		*586)
+-			OPTIMIZATION="${OPTIMIZATION} -march=i586 \
+-				-mtune=native"
+-			;;
+-		*686)
+-			OPTIMIZATION="${OPTIMIZATION} -march=i686 \
+-				-mtune=native"
++			OPTIMIZATION="${OPTIMIZATION} -march=i586"
+ 			;;
+ 		*86)
+-			OPTIMIZATION="${OPTIMIZATION} -march=native \
+-				-mtune=native"
++			OPTIMIZATION="${OPTIMIZATION} -march=i686"
+ 			;;
+ 		esac
+ 


### PR DESCRIPTION
This pull request makes the library build on ARM-based (M1, M2, ...) Macs.

Changes:
- Use sh and cp in a way that is Mac compatible
- Try multiple Android toolchain paths
- Patch LAME configure script to not assume it is running on an x86(_64) system